### PR TITLE
Modified crash display query to properly group based on verification status

### DIFF
--- a/server/status.php
+++ b/server/status.php
@@ -10,8 +10,8 @@
 	require_once 'config.php';
 	
 	$verified_unknown       = 0;
-	$verified_interesting   = 1;
-	$verified_uninteresting = 2;
+	$verified_uninteresting = 1;
+	$verified_interesting   = 2;
 	$verified_exploitable   = 3;
 	
 	function update_node_crash_status( $node, $time )


### PR DESCRIPTION
Modified 'verified' property so that it lists verification status based on importance incrementally.

$verified_unknown = 0;
$verified_uninteresting = 1;
$verified_interesting = 2;
$verified_exploitable = 3;

Then modified the crash display query to use groupwise max in order to only display top level (highest) value assigned to 'verified' when displaying unique crashes only.  This ensures that when crashes are deleted from the database that they will be displayed properly in the UI.
