### PR TITLE
Check debugger_restart_minutes for nil in config.rb

### DIFF
--- a/node/core/configuration.rb
+++ b/node/core/configuration.rb
@@ -138,7 +138,7 @@ def config_test
 		return false
 	end
 		
-	if( $debugger_restart_minutes.to_i < 5 )
+	if( $debugger_restart_minutes and $debugger_restart_minutes < 5 )
 		print_warning( "Warning, you have set the debugger to restart every #{$debugger_restart_minutes} minutes, The Grinder Server will see this node as inactive unless you use a value of more than 5 minutes." )
 	end
 		


### PR DESCRIPTION
In node's `config.rb`, the comment for `$debugger_restart_minutes` says: "Set to nil to disable this feature (restarting debugger)". What happens is if you do set this to nil, `$debugger_restart_minutes` will be evaluated this way in `configuration.rb`:

``` ruby
if($debugger_restart_minutes < 5 )
    print_warning( "Warning, you have set the debugger to restart every #{$debugger_restart_minutes} minutes, The Grinder Server will see this node as inactive unless you use a value of more than 5 minutes." )
end
```

When you do nil < 5, you should get:

```
NoMethodError: undefined method `<' for nil:NilClass
```

So this PR fixes that.

I looked around a bit more to see if the same problem exists elsewhere, didn't see anything. `grinder.rb` uses `$debugger_restart_minutes` too for the sleep function, but nil condition is already checked in there before calculation. That's probably it.
