### PR TITLE
Support config.rb testcase default options

### DIFF
--- a/node/testcase.rb
+++ b/node/testcase.rb
@@ -107,7 +107,7 @@ class Testcase
 		end
 		
 		# merge in the command line options over the options from the config file.
-		@opts = $testcase_opts.merge( @opts )
+		@opts = @opts.merge($testcase_opts)
 		
 		html = xmlcrashlog.generate_html( @opts, @skip_elem )
 		


### PR DESCRIPTION
The `testcase.rb` script does not actually load `config.rb`'s `$testcase_opts`, because looks like the merge method in `testcase.rb`'s run() is used incorrectly.
