### PR TITLE
Add a check to see if the node server is down or not

### DIFF
--- a/node/grinder.rb
+++ b/node/grinder.rb
@@ -137,6 +137,12 @@ class Grinder
 		return true
 	end
 
+	def get_pids
+		pid_list = []
+		Metasm::WinOS.list_processes.sort_by {|p| pid_list << p.pid}
+		pid_list
+	end
+
 	def run
 	
 		if( not config_init( @config_file ) )
@@ -168,6 +174,11 @@ class Grinder
 		while( true )
 		
 			kill_thread  = nil
+
+			if $server_pid and !get_pids.include?($server_pid)
+				print_error("Grinder server is down")
+				$server_pid = nil
+			end
 
 			if( not $server_pid )
 				$server_pid = ::Process.spawn( "#{$ruby_vm} -I. .\\core\\server.rb --config=#{@config_file} --browser=#{@browser_type} #{ ( @fuzzer ? '--fuzzer='+@fuzzer : '' ) } #{ ( not @verbose ? '--quiet' : '' ) }" )


### PR DESCRIPTION
This PR is related to issue #40 (Node server shuts down and cannot restart). I haven't got a chance to actually look into why the node server goes down in some cases, but I feel it is definitely necessary for grinder to be able to restart the node server as long as the debugger is alive. If not, the debugging will just keep respawning the browser without any testcases.

Please note that I am not 100% familiar with grinder, so I'm not super confident if this implementation is appropriate or not. If you don't like it, please feel free to close.